### PR TITLE
Restore team roles table removed during merge conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
-[![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/6B-rL6oS)
-# Collaborative Git Workflows
-
-| Key              | Value                                                                                                                                                                                                                                                        |
-|:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Course Codes** | BBT 4106                                                                                                                                                                                                                     |
-| **Course Names** | BBT 4106: Business Intelligence I (Week 1-3 of 13)                                                                                                                                                                             |
-| **Semester**     | April to July 2026                                                                                                                                                                                                           |
-| **Lecturer**     | Allan Omondi                                                                                                                                                                                                                 |
-| **Contact**      | aomondi@strathmore.edu                                                                                                                                                                                                       |
-| **Note**         | The lecture contains both theory and practice.<br/>This notebook forms part of the practice.<br/>It is intended for educational purpose only.<br/>Recommended citation: [BibTex](https://raw.githubusercontent.com/course-files/Git/refs/heads/main/RecommendedCitation.bib) |
-
 ## Lab Manuals
 
 Refer to the files in the order specified below for more details:
 
 - [lab_instructions_part1.md](lab_instructions_part1.md)
 - [lab_instructions_part2.md](lab_instructions_part2.md)
-Project lead: Member 5 — responsible for governance and audit.
-Project lead: Member 5 — responsible for governance and audit.
-Project lead: Member 5 — responsible for governance and audit.
+
+## Team Roles
+
+| Member   | Name            | Role                                   |
+| -------- | --------------- | -------------------------------------- |
+| Member 1 | Yeshua Kimani   | Team Lead & Repository Setup           |
+| Member 2 | Gibson Kingori  | Data Sources Research                  |
+| Member 3 | Steve Mochoge   | Star Schema & Data Governance Research |
+| Member 4 | Desmond Turkmen | ETL/ELT Research                       |


### PR DESCRIPTION
Restored the Team Roles table that was accidentally removed during 
a merge conflict resolution in a previous commit.

The table documents each team member's name and role for clarity 
and accountability across the project lifecycle.

Closes #2